### PR TITLE
Update if2.rs

### DIFF
--- a/exercises/if/if2.rs
+++ b/exercises/if/if2.rs
@@ -9,8 +9,10 @@
 pub fn fizz_if_foo(fizzish: &str) -> &str {
     if fizzish == "fizz" {
         "foo"
+    } else if fizzish == "fuzz" {
+        "bar"
     } else {
-        1
+        "baz"
     }
 }
 
@@ -32,5 +34,9 @@ mod tests {
     #[test]
     fn default_to_baz() {
         assert_eq!(fizz_if_foo("literally anything"), "baz")
+    }
+    #[test]
+    fn default_to_baz2() {
+        assert_eq!(fizz_if_foo("other thing"), "baz")
     }
 }


### PR DESCRIPTION
// if2.rs

// Step 1: Make me compile!
// Step 2: Get the bar_for_fuzz and default_to_baz tests passing!
// Execute the command `rustlings hint if2` if you want a hint :)

// I AM NOT DONE

pub fn fizz_if_foo(fizzish: &str) -> &str {
    if fizzish == "fizz" {
        "foo"
    } else if fizzish == "fuzz" {
        "bar"
    } else {
        "baz"
    }
}

// No test changes needed!
#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    fn foo_for_fizz() {
        assert_eq!(fizz_if_foo("fizz"), "foo")
    }

    #[test]
    fn bar_for_fuzz() {
        assert_eq!(fizz_if_foo("fuzz"), "bar")
    }

    #[test]
    fn default_to_baz() {
        assert_eq!(fizz_if_foo("literally anything"), "baz")
    }
    #[test]
    fn default_to_baz2() {
        assert_eq!(fizz_if_foo("other thing"), "baz")
    }
}
